### PR TITLE
Tweak apachebench script and delay timer

### DIFF
--- a/apachebench.tf
+++ b/apachebench.tf
@@ -3,7 +3,8 @@ resource "time_sleep" "wait_30_seconds" {
   depends_on = [
     aws_autoscaling_group.autoscaling_group,
     aws_cloudwatch_metric_alarm.low_cpu,
-    aws_cloudwatch_metric_alarm.high_cpu
+    aws_cloudwatch_metric_alarm.high_cpu,
+    aws_lb.loadbalancer
   ]
 }
 
@@ -14,8 +15,9 @@ resource "null_resource" "apachebench" {
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
     command     = <<-CMD
-      curl -o ab ${var.apachebench_url} && \
-      ab -n ${var.test_requests} -c ${var.test_concurrency} -r -q http://${aws_lb.loadbalancer.dns_name}${var.app_test_url}
+      curl -s -o ab ${var.apachebench_url} && \
+      chmod 0755 ab && \
+      ./ab -n ${var.test_requests} -c ${var.test_concurrency} -r -q http://${aws_lb.loadbalancer.dns_name}${var.app_test_url}
     CMD
   }
   depends_on = [time_sleep.wait_30_seconds]

--- a/variables.tf
+++ b/variables.tf
@@ -55,8 +55,8 @@ variable "autoscaling_threshold" {
     high = number
   })
   default = {
-    low : 20,
-    high : 60
+    low  = 20
+    high = 60
   }
 }
 


### PR DESCRIPTION
* Hopefully fixed ab script.
* 30 second delay timer should depend on the load balancer, too.
* Reformatted `autoscaling_threshold` default value.